### PR TITLE
Update pakrat.spec

### DIFF
--- a/packaging/pakrat.spec
+++ b/packaging/pakrat.spec
@@ -8,7 +8,7 @@ release: 1%{?dist}
 buildarch: noarch
 license: MIT
 source0: %{name}.tar.gz
-buildrequires: yum, createrepo, python-setuptools-devel
+buildrequires: yum, createrepo, python-setuptools
 requires: yum, createrepo
 
 %description


### PR DESCRIPTION
Changed python-setuptools-devel requirement to python-setuptools, the older version being deprecated and removed. See https://fedoraproject.org/wiki/Changes/Remove_Python-setuptools-devel